### PR TITLE
JSON: Add the capability to read/write the raw serialized content of a node

### DIFF
--- a/Verse/src/DecoderDescriptors/Tree/IReader.cs
+++ b/Verse/src/DecoderDescriptors/Tree/IReader.cs
@@ -13,6 +13,8 @@ namespace Verse.DecoderDescriptors.Tree
 
 		ReaderStatus ReadToValue(TState state, out TNative value);
 
+		ReaderStatus ReadRawToValue(TState state, out TNative value);
+
 		TState Start(Stream stream, ErrorEvent error);
 
 		void Stop(TState state);

--- a/Verse/src/DecoderDescriptors/TreeDecoderDescriptor.cs
+++ b/Verse/src/DecoderDescriptors/TreeDecoderDescriptor.cs
@@ -131,6 +131,30 @@ namespace Verse.DecoderDescriptors
 			};
 		}
 
+		public void HasRawContent<TValue>(Setter<TEntity, TValue> setter)
+		{
+			var converter = this.converter.Get<TValue>();
+
+			this.definition.Callback = (IReader<TState, TNative, TKey> reader, TState state, ref TEntity entity) =>
+			{
+				var readStatus = reader.ReadRawToValue(state, out var value);
+				if (readStatus == ReaderStatus.Failed)
+				{
+					entity = default;
+					return ReaderStatus.Failed;
+				}
+				else if (readStatus == ReaderStatus.Ignored)
+				{
+					return ReaderStatus.Ignored;
+				}
+
+				// FIXME: support conversion failures
+				setter(ref entity, converter(value));
+
+				return ReaderStatus.Succeeded;
+			};
+		}
+
 		private static TreeDecoderDescriptor<TState, TNative, TKey, TElement> BindArray<TElement>(
 			IReaderDefinition<TState, TNative, TKey, TEntity> parentDefinition, Func<TElement> constructor,
 			Setter<TEntity, IEnumerable<TElement>> setter,

--- a/Verse/src/EncoderDescriptors/Tree/IWriter.cs
+++ b/Verse/src/EncoderDescriptors/Tree/IWriter.cs
@@ -16,5 +16,7 @@ namespace Verse.EncoderDescriptors.Tree
 			IReadOnlyDictionary<string, WriterCallback<TState, TNative, TObject>> fields);
 
 		void WriteAsValue(TState state, TNative value);
+
+		void WriteAsRawValue(TState state, TNative value);
 	}
 }

--- a/Verse/src/EncoderDescriptors/TreeEncoderDescriptor.cs
+++ b/Verse/src/EncoderDescriptors/TreeEncoderDescriptor.cs
@@ -82,6 +82,13 @@ namespace Verse.EncoderDescriptors
 			TreeEncoderDescriptor<TState, TNative, TEntity>.BindValue(this.definition, converter);
 		}
 
+		public void HasRawContent<TValue>(Func<TEntity, TValue> getter)
+		{
+			var native = this.converter.Get<TValue>();
+
+			this.definition.Callback = (writer, state, entity) => writer.WriteAsRawValue(state, native(getter(entity)));
+		}
+
 		private static IEncoderDescriptor<TElement> BindArray<TElement>(
 			IWriterDefinition<TState, TNative, TEntity> parent, Func<TEntity, IEnumerable<TElement>> getter,
 			TreeEncoderDescriptor<TState, TNative, TElement> elementDescriptor)

--- a/Verse/src/IDecoderDescriptor.cs
+++ b/Verse/src/IDecoderDescriptor.cs
@@ -85,5 +85,15 @@ namespace Verse
 		/// with current schema or have a custom decoder declared.
 		/// </summary>
 		void HasValue();
+
+		/// <summary>
+		/// Declare entity as a raw encoded content.
+		/// For instance, for JSON, declaring a raw encoded content will
+		/// provide the serialized form of the JSON at this point of the
+		/// hierarchy.
+		/// </summary>
+		/// <typeparam name="TValue">Value type</typeparam>
+		/// <param name="setter">Value to entity converter</param>
+		void HasRawContent<TValue>(Setter<TEntity, TValue> setter);
 	}
 }

--- a/Verse/src/IEncoderDescriptor.cs
+++ b/Verse/src/IEncoderDescriptor.cs
@@ -78,5 +78,15 @@ namespace Verse
 		/// with current schema or have a custom encoder declared.
 		/// </summary>
 		void HasValue();
+
+		/// <summary>
+		/// Declare entity as a raw encoded content and use given converter to access it.
+		/// This will write the value as is at this point of the hierarchy.
+		/// Value type must be natively compatible with current schema or have
+		/// a custom encoder declared.
+		/// </summary>
+		/// <typeparam name="TValue">Value type</typeparam>
+		/// <param name="getter">Entity to value getter</param>
+		void HasRawContent<TValue>(Func<TEntity, TValue> getter);
 	}
 }

--- a/Verse/src/Schemas/JSON/Reader.cs
+++ b/Verse/src/Schemas/JSON/Reader.cs
@@ -180,6 +180,28 @@ namespace Verse.Schemas.JSON
 			}
 		}
 
+		public ReaderStatus ReadRawToValue(ReaderState state, out JSONValue value)
+		{
+			var builder = new StringBuilder();
+			state.OnCharacterRead = character => builder.Append((char) character);
+
+			try
+			{
+				if (this.Skip(state))
+				{
+					value = JSONValue.FromString(builder.ToString());
+					return ReaderStatus.Succeeded;
+				}
+			}
+			finally
+			{
+				state.OnCharacterRead = null;
+			}
+
+			value = default;
+			return ReaderStatus.Failed;
+		}
+
 		public ReaderState Start(Stream stream, ErrorEvent error)
 		{
 			return new ReaderState(stream, this.encoding, error);

--- a/Verse/src/Schemas/JSON/ReaderState.cs
+++ b/Verse/src/Schemas/JSON/ReaderState.cs
@@ -7,6 +7,7 @@ namespace Verse.Schemas.JSON
 	internal class ReaderState : IDisposable
 	{
 		public int Current;
+		public Action<int> OnCharacterRead { get; set; }
 
 		private readonly ErrorEvent error;
 
@@ -161,6 +162,7 @@ namespace Verse.Schemas.JSON
 
 		public void Read()
 		{
+			this.OnCharacterRead?.Invoke(this.Current);
 			this.Current = this.reader.Read();
 
 			++this.position;

--- a/Verse/src/Schemas/JSON/Writer.cs
+++ b/Verse/src/Schemas/JSON/Writer.cs
@@ -66,5 +66,19 @@ namespace Verse.Schemas.JSON
 		{
 			state.Value(value);
 		}
+
+		public void WriteAsRawValue(WriterState state, JSONValue value)
+		{
+			if (value.Type == JSONType.String)
+			{
+				state.RawJson(value.String);
+			}
+			else
+			{
+				// Normally, it is expected that raw values are only string
+				// But we can easily write raw JSON from null, booleans and numbers
+				this.WriteAsValue(state, value);
+			}
+		}
 	}
 }

--- a/Verse/src/Schemas/JSON/WriterState.cs
+++ b/Verse/src/Schemas/JSON/WriterState.cs
@@ -126,6 +126,13 @@ namespace Verse.Schemas.JSON
 			this.needComma = true;
 		}
 
+		public void RawJson(string json)
+		{
+			this.Prefix();
+			this.writer.Write(json);
+			this.needComma = true;
+		}
+
 		private void Prefix()
 		{
 			if (this.needComma)

--- a/Verse/src/Schemas/Protobuf/Reader.cs
+++ b/Verse/src/Schemas/Protobuf/Reader.cs
@@ -280,6 +280,11 @@ namespace Verse.Schemas.Protobuf
 			throw new NotImplementedException();
 		}
 
+		public ReaderStatus ReadRawToValue(ReaderState state, out ProtobufValue value)
+		{
+			throw new NotImplementedException();
+		}
+
 		public ReaderState Start(Stream stream, ErrorEvent error)
 		{
 			return new ReaderState(stream, error);

--- a/Verse/src/Schemas/Protobuf/Writer.cs
+++ b/Verse/src/Schemas/Protobuf/Writer.cs
@@ -33,5 +33,10 @@ namespace Verse.Schemas.Protobuf
 		{
 			throw new NotImplementedException();
 		}
+
+		public void WriteAsRawValue(WriterState state, ProtobufValue value)
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/Verse/src/Schemas/QueryString/Reader.cs
+++ b/Verse/src/Schemas/QueryString/Reader.cs
@@ -125,6 +125,11 @@ namespace Verse.Schemas.QueryString
 			}
 		}
 
+		public ReaderStatus ReadRawToValue(ReaderState state, out string value)
+		{
+			throw new NotImplementedException();
+		}
+
 		public ReaderState Start(Stream stream, ErrorEvent error)
 		{
 			var state = new ReaderState(stream, this.encoding, error);

--- a/Verse/src/Schemas/RawProtobuf/Reader.cs
+++ b/Verse/src/Schemas/RawProtobuf/Reader.cs
@@ -85,6 +85,11 @@ namespace Verse.Schemas.RawProtobuf
 			return state.TryReadValue(out value) ? ReaderStatus.Succeeded : ReaderStatus.Failed;
 		}
 
+		public ReaderStatus ReadRawToValue(ReaderState state, out RawProtobufValue value)
+		{
+			throw new NotImplementedException();
+		}
+
 		public ReaderState Start(Stream stream, ErrorEvent error)
 		{
 			return new ReaderState(stream, error, this.noZigZagEncoding);

--- a/Verse/src/Schemas/RawProtobuf/Writer.cs
+++ b/Verse/src/Schemas/RawProtobuf/Writer.cs
@@ -58,5 +58,10 @@ namespace Verse.Schemas.RawProtobuf
 		{
 			state.Value(value);
 		}
+
+		public void WriteAsRawValue(WriterState state, RawProtobufValue value)
+		{
+			throw new System.NotImplementedException();
+		}
 	}
 }


### PR DESCRIPTION
This feature is only available on JSON as its grammar easily allow to read
schemaless content.

# Reading
The decoder is performing a check on the format while gathering the raw
content.

This feature can be useful when we don't know the schema of a JSON and
that we want to handle it as a raw string/dictionary; or when we want to
defer the deserialization of a sub part.

# Writting
This is the dual of the reading part making it possible to execute
roundtrip with raw JSON.

Note that the encoder doesn't check the syntax.

# Potential improvements
When reading a JSON, it is not possible to mix raw content and normal
content on the same node. For instance it is not possible to do this:
```csharp
var schema = new JSONSchema<string[]>();
var root = schema.DecoderDescriptor;

root.HasField("value1", () => 0, (ref string[] e, int v) => e[0] = v.ToString()).HasValue();
root.HasRawContent((ref string[] e, string v) => e[1] = v);
root.HasField("value2", () => false, (ref string[] e, bool v) => e[2] = v.ToString()).HasValue();

var json = "{\"value1\": 42, \"value2\": true}";
read(root, json);
```

But this requires to support multiple handlers per node which might
add a lot of refactoring and drop to perf.  Also, this solution would break
the read/write symmetry as it weird to write several values at the same
node.

# Potential issues
This slightly breaks the symmetry of read/write. It is possible to read
both normal content and raw content from an array as here:

```csharp
var schema = new JSONSchema<string[]>();
var root = schema.DecoderDescriptor;

root.HasField("0").HasValue((ref string[] e, string v) => e[0] = v);
root.HasField("1").HasRawContent((ref string[] e, string v) => e[1] = v);

var json = "[\"foo\", [\"bar\"]]";
JSONSchemaTester.AssertDecodeAndEqual(schema, () => new[] {"", ""}, json, new[] {"foo", "[\"bar\"]"});
```

But doing the same structure with an encoder will produce:
`{"0": "foo", "1": ["bar"]}`
