### PR TITLE
Extract `{Reader,Writer}Callback` out of `I{Reader,Writer}Definition`.

### DIFF
--- a/src/Verse.Test/Schemas/QueryStringSchemaTester.cs
+++ b/src/Verse.Test/Schemas/QueryStringSchemaTester.cs
@@ -12,7 +12,11 @@ public class QueryStringSchemaTester
     [TestCase("?a&")]
     public void DecodeSuccess(string query)
     {
-        Decode(Schema.CreateQueryString<string>(), query);
+        var schema = Schema.CreateQueryString<string>();
+
+        schema.DecoderDescriptor.IsObject(() => null);
+
+        Decode(schema, query);
     }
 
     [Test]

--- a/src/Verse/DecoderDescriptors/Tree/IReaderDefinition.cs
+++ b/src/Verse/DecoderDescriptors/Tree/IReaderDefinition.cs
@@ -2,8 +2,6 @@ namespace Verse.DecoderDescriptors.Tree;
 
 internal interface IReaderDefinition<TState, TNative, TKey, TEntity>
 {
-    ReaderCallback<TState, TNative, TKey, TEntity> Callback { get; set; }
-
     ILookup<TKey, ReaderCallback<TState, TNative, TKey, TEntity>> Lookup { get; }
 
     IReaderDefinition<TState, TNative, TKey, TOther> Create<TOther>();

--- a/src/Verse/DecoderDescriptors/Tree/ReaderLayer.cs
+++ b/src/Verse/DecoderDescriptors/Tree/ReaderLayer.cs
@@ -1,0 +1,8 @@
+namespace Verse.DecoderDescriptors.Tree;
+
+internal record ReaderLayer<TState, TNative, TKey, TEntity>(
+    IReaderDefinition<TState, TNative, TKey, TEntity> Definition)
+{
+    public ReaderCallback<TState, TNative, TKey, TEntity> Callback =
+        (IReader<TState, TNative, TKey> _, TState _, ref TEntity _) => ReaderStatus.Failed;
+}

--- a/src/Verse/EncoderDescriptors/Tree/IWriterDefinition.cs
+++ b/src/Verse/EncoderDescriptors/Tree/IWriterDefinition.cs
@@ -4,8 +4,6 @@ namespace Verse.EncoderDescriptors.Tree;
 
 internal interface IWriterDefinition<TState, TNative, TEntity>
 {
-    WriterCallback<TState, TNative, TEntity> Callback { get; set; }
-
     Dictionary<string, WriterCallback<TState, TNative, TEntity>> Fields { get; }
 
     IWriterDefinition<TState, TNative, TOther> Create<TOther>();

--- a/src/Verse/EncoderDescriptors/Tree/WriterLayer.cs
+++ b/src/Verse/EncoderDescriptors/Tree/WriterLayer.cs
@@ -1,0 +1,6 @@
+namespace Verse.EncoderDescriptors.Tree;
+
+internal record WriterLayer<TState, TNative, TEntity>(IWriterDefinition<TState, TNative, TEntity> Definition)
+{
+    public WriterCallback<TState, TNative, TEntity> Callback = (_, _, _) => { };
+}

--- a/src/Verse/Schemas/Json/ReaderDefinition.cs
+++ b/src/Verse/Schemas/Json/ReaderDefinition.cs
@@ -6,10 +6,6 @@ namespace Verse.Schemas.Json;
 
 internal class ReaderDefinition<TEntity> : IReaderDefinition<ReaderState, JsonValue, int, TEntity>
 {
-    public ReaderCallback<ReaderState, JsonValue, int, TEntity> Callback { get; set; } =
-        (IReader<ReaderState, JsonValue, int> reader, ReaderState state, ref TEntity entity) =>
-            reader.ReadToValue(state, out _);
-
     public ILookup<int, ReaderCallback<ReaderState, JsonValue, int, TEntity>> Lookup { get; } =
         new IndexOrNameLookup<ReaderCallback<ReaderState, JsonValue, int, TEntity>>();
 

--- a/src/Verse/Schemas/Json/WriterDefinition.cs
+++ b/src/Verse/Schemas/Json/WriterDefinition.cs
@@ -6,9 +6,6 @@ namespace Verse.Schemas.Json;
 
 internal class WriterDefinition<TEntity> : IWriterDefinition<WriterState, JsonValue, TEntity>
 {
-    public WriterCallback<WriterState, JsonValue, TEntity> Callback { get; set; } = (reader, state, _) =>
-        reader.WriteAsValue(state, JsonValue.Undefined);
-
     public Dictionary<string, WriterCallback<WriterState, JsonValue, TEntity>> Fields { get; } = new();
 
     public IWriterDefinition<WriterState, JsonValue, TOther> Create<TOther>()

--- a/src/Verse/Schemas/Protobuf/ReaderDefinition.cs
+++ b/src/Verse/Schemas/Protobuf/ReaderDefinition.cs
@@ -6,8 +6,6 @@ namespace Verse.Schemas.Protobuf;
 
 internal class ProtobufReaderDefinition<TEntity> : IReaderDefinition<ReaderState, ProtobufValue, int, TEntity>
 {
-    public ReaderCallback<ReaderState, ProtobufValue, int, TEntity> Callback { get; set; }
-
     public ILookup<int, ReaderCallback<ReaderState, ProtobufValue, int, TEntity>> Lookup { get; }
 
     //private static readonly Reader<TEntity> emptyReader = new Reader<TEntity>(new ProtoBinding[0], false);
@@ -20,7 +18,6 @@ internal class ProtobufReaderDefinition<TEntity> : IReaderDefinition<ReaderState
 
     public ProtobufReaderDefinition(ProtoBinding[] bindings, bool rejectUnknown)
     {
-        Callback = (IReader<ReaderState, ProtobufValue, int> _, ReaderState _, ref TEntity _) => ReaderStatus.Failed;
         Lookup = null!; // FIXME
 
         _bindings = bindings;

--- a/src/Verse/Schemas/Protobuf/WriterDefinition.cs
+++ b/src/Verse/Schemas/Protobuf/WriterDefinition.cs
@@ -5,22 +5,13 @@ using Verse.Schemas.Protobuf.Definition;
 
 namespace Verse.Schemas.Protobuf;
 
-internal class ProtobufWriterDefinition<TEntity> : IWriterDefinition<WriterState, ProtobufValue, TEntity>
+internal class ProtobufWriterDefinition<TEntity>(ProtoBinding[] fields) :
+    IWriterDefinition<WriterState, ProtobufValue, TEntity>
 {
-    private readonly ProtoBinding[] _fields;
-
-    public ProtobufWriterDefinition(ProtoBinding[] fields)
-    {
-        _fields = fields;
-    }
-
-    public WriterCallback<WriterState, ProtobufValue, TEntity> Callback { get; set; } = (reader, state, entity) =>
-        reader.WriteAsValue(state, ProtobufValue.Empty);
-
     public Dictionary<string, WriterCallback<WriterState, ProtobufValue, TEntity>> Fields { get; } = new();
 
     public IWriterDefinition<WriterState, ProtobufValue, TOther> Create<TOther>()
     {
-        return new ProtobufWriterDefinition<TOther>(_fields);
+        return new ProtobufWriterDefinition<TOther>(fields);
     }
 }

--- a/src/Verse/Schemas/QueryString/ReaderDefinition.cs
+++ b/src/Verse/Schemas/QueryString/ReaderDefinition.cs
@@ -5,10 +5,6 @@ namespace Verse.Schemas.QueryString;
 
 internal class ReaderDefinition<TEntity> : IReaderDefinition<ReaderState, string, char, TEntity>
 {
-    public ReaderCallback<ReaderState, string, char, TEntity> Callback { get; set; } =
-        (IReader<ReaderState, string, char> reader, ReaderState state, ref TEntity entity) =>
-            reader.ReadToValue(state, out _);
-
     public ILookup<char, ReaderCallback<ReaderState, string, char, TEntity>> Lookup { get; } =
         new NameLookup<ReaderCallback<ReaderState, string, char, TEntity>>();
 

--- a/src/Verse/Schemas/RawProtobuf/ReaderDefinition.cs
+++ b/src/Verse/Schemas/RawProtobuf/ReaderDefinition.cs
@@ -6,10 +6,6 @@ namespace Verse.Schemas.RawProtobuf;
 
 internal class ReaderDefinition<TEntity> : IReaderDefinition<ReaderState, RawProtobufValue, char, TEntity>
 {
-    public ReaderCallback<ReaderState, RawProtobufValue, char, TEntity> Callback { get; set; } =
-        (IReader<ReaderState, RawProtobufValue, char> reader, ReaderState state,
-            ref TEntity entity) => reader.ReadToValue(state, out _);
-
     public ILookup<char, ReaderCallback<ReaderState, RawProtobufValue, char, TEntity>> Lookup { get; } =
         new NameLookup<ReaderCallback<ReaderState, RawProtobufValue, char, TEntity>>();
 

--- a/src/Verse/Schemas/RawProtobuf/WriterDefinition.cs
+++ b/src/Verse/Schemas/RawProtobuf/WriterDefinition.cs
@@ -6,9 +6,6 @@ namespace Verse.Schemas.RawProtobuf;
 
 internal class WriterDefinition<TEntity> : IWriterDefinition<WriterState, RawProtobufValue, TEntity>
 {
-    public WriterCallback<WriterState, RawProtobufValue, TEntity> Callback { get; set; } =
-        (reader, state, _) => reader.WriteAsValue(state, new RawProtobufValue());
-
     public Dictionary<string, WriterCallback<WriterState, RawProtobufValue, TEntity>> Fields { get; } = new();
 
     public IWriterDefinition<WriterState, RawProtobufValue, TOther> Create<TOther>()


### PR DESCRIPTION
This mutable field doesn't need abstract definition and therefore can be moved outside from the interface.